### PR TITLE
Add support for links with blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can then use the functions as follow:
   <ul>
     <%= active_link(@conn, "Dashboard", to: "/", active: [{Dashboard, :index}], wrap_tag: :li) %>
     <%= active_link(@conn, "Users", to: "/users", wrap_tag: :li) %>
+    <%= active_link(@conn, to: "/users", wrap_tag: :li) do %>
+      <img src="foo.png">
+    <% end %>
   </ul>
 </header>
 ```

--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -49,6 +49,10 @@ defmodule PhoenixActiveLink do
     <%= active_link(@conn, "Link text", to: "/my/path", active: :exact) %>
     ```
   """
+  def active_link(conn, opts, do: contents) when is_list(opts) do
+    active_link(conn, contents, opts)
+  end
+
   def active_link(conn, text, opts) do
     opts = Keyword.merge(default_opts, opts)
     active? = active_path?(conn, opts)

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -65,6 +65,19 @@ defmodule PhoenixActiveLinkTest do
     assert link == link("Link", to: "/foo", class: "disabled bar")
   end
 
+  test "active_link with a block" do
+    content = content_tag(:p, "Hello")
+    expected = link(to: "/foo", class: "") do
+      content
+    end
+
+    result = active_link(conn(path: "/"), to: "/foo") do
+       content
+    end
+
+    assert result == expected
+  end
+
   test "active_link with :wrap_tag" do
     expected = content_tag(:li, link("Link", to: "/foo", class: "active"), class: "active")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo", wrap_tag: :li) == expected


### PR DESCRIPTION
Previously, you were unable to use `active_link` to create a link with a block. This is useful for embedding an image, or other HTML tags in the link.