### PR TITLE
Bump package version in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `phoenix_active_link` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:phoenix_active_link, "~> 0.0.1"}]
+  [{:phoenix_active_link, "~> 0.1.1"}]
 end
 ```
 


### PR DESCRIPTION
Totally not necessary, but nice to have the latest one there.

Mechanically copied and pasted the old version myself, then wasted ~5 minutes looking into the warnings about `deps()` and `package()`.

Thanks for this nice little package!