### PR TITLE
Add the active option :exact_with_params

### DIFF
--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -57,23 +57,42 @@ defmodule PhoenixActiveLinkTest do
 
   test "active_link without :wrap_tag" do
     assert active_link(conn(path: "/"), "Link", to: "/foo") == link("Link", to: "/foo", class: "")
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo") == link("Link", to: "/foo", class: "active")
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar") == link("Link", to: "/foo", class: "active bar")
-    link = active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar", class_active: "enabled")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo") ==
+             link("Link", to: "/foo", class: "active")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar") ==
+             link("Link", to: "/foo", class: "active bar")
+
+    link =
+      active_link(conn(path: "/foo"), "Link", to: "/foo", class: "bar", class_active: "enabled")
+
     assert link == link("Link", to: "/foo", class: "enabled bar")
-    link = active_link(conn(path: "/bar"), "Link", to: "/foo", class: "bar", class_inactive: "disabled")
+
+    link =
+      active_link(
+        conn(path: "/bar"),
+        "Link",
+        to: "/foo",
+        class: "bar",
+        class_inactive: "disabled"
+      )
+
     assert link == link("Link", to: "/foo", class: "disabled bar")
   end
 
   test "active_link with a block" do
     content = content_tag(:p, "Hello")
-    expected = link(to: "/foo", class: "") do
-      content
-    end
 
-    result = active_link(conn(path: "/"), to: "/foo") do
-       content
-    end
+    expected =
+      link to: "/foo", class: "" do
+        content
+      end
+
+    result =
+      active_link conn(path: "/"), to: "/foo" do
+        content
+      end
 
     assert result == expected
   end
@@ -82,18 +101,50 @@ defmodule PhoenixActiveLinkTest do
     expected = content_tag(:li, link("Link", to: "/foo", class: "active"), class: "active")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo", wrap_tag: :li) == expected
 
-    expected = content_tag(:li, link("Link", to: "/foo", class: "disabled"), class: "disabled foo")
-    link = active_link(conn(path: "/bar"), "Link", to: "/foo", class_inactive: "disabled", wrap_tag: :li, wrap_tag_opts: [class: "foo"])
+    expected =
+      content_tag(:li, link("Link", to: "/foo", class: "disabled"), class: "disabled foo")
+
+    link =
+      active_link(
+        conn(path: "/bar"),
+        "Link",
+        to: "/foo",
+        class_inactive: "disabled",
+        wrap_tag: :li,
+        wrap_tag_opts: [class: "foo"]
+      )
+
     assert link == expected
   end
 
+  test "active_link with :exact_with_params" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar=baz"),
+             "Link",
+             to: "/foo?bar=baz",
+             active: :exact_with_params,
+             class: "link"
+           ) == link("Link", to: "/foo?bar=baz", class: "active link")
+  end
+
+  test "active_link with :exact_with_params without active class" do
+    assert active_link(
+             conn(path: "/foo", query_string: "bar=1&baz=2"),
+             "Link",
+             to: "/foo?baz=1&bar=2",
+             active: :exact_with_params
+           ) == link("Link", to: "/foo?baz=1&bar=2", class: "")
+  end
+
   test "customize defaults" do
-    Application.put_env(:phoenix_active_link, :defaults, [wrap_tag: :li])
+    Application.put_env(:phoenix_active_link, :defaults, wrap_tag: :li)
     expected = content_tag(:li, link("Link", to: "/foo", class: "active"), class: "active")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo") == expected
 
-    Application.put_env(:phoenix_active_link, :defaults, [class_active: "enabled"])
-    assert active_link(conn(path: "/foo"), "Link", to: "/foo") == link("Link", to: "/foo", class: "enabled")
+    Application.put_env(:phoenix_active_link, :defaults, class_active: "enabled")
+
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo") ==
+             link("Link", to: "/foo", class: "enabled")
   after
     Application.put_env(:phoenix_active_link, :defaults, [])
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,10 +5,10 @@ defmodule TestHelpers do
     %Plug.Conn{}
     |> Map.put(:private, make_private(opts))
     |> Map.put(:request_path, opts[:path])
+    |> Map.put(:query_string, opts[:query_string] || "")
   end
 
   defp make_private(opts) do
-    %{phoenix_controller: opts[:controller],
-      phoenix_action: opts[:action]}
+    %{phoenix_controller: opts[:controller], phoenix_action: opts[:action]}
   end
 end


### PR DESCRIPTION
- [x] `active: :exact_with_params` this will add the query string to the `request_path` and checks if the `to` and new `request path` are equal.
- [ ] `active: :inclusive_with_params` this will check the same as `:inclusive` but also checks if the query_params of the `to`-link are present in the `conn.query_params`
