### PR TITLE
Add the active option :exact_with_params

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -90,6 +90,8 @@ defmodule PhoenixActiveLink do
     * a `{controller, action}` list - A list of tuples with a controller module and an action symbol.
 
         Both can be the `:any` symbol to match any controller or action.
+    * `:exact_with_params`     - Will return `true` if the current path and the link path are exactly the same,
+       including trailing slashes and query string as is.
 
   ## Examples
 
@@ -110,6 +112,7 @@ defmodule PhoenixActiveLink do
       :inclusive -> starts_with_path?(conn.request_path, to)
       :exclusive -> String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
       :exact     -> conn.request_path == to
+      :exact_with_params -> request_path_with_params(conn) == to
       %Regex{} = regex -> Regex.match?(regex, conn.request_path)
       controller_actions when is_list(controller_actions) ->
         controller_actions_active?(conn, controller_actions)
@@ -127,6 +130,13 @@ defmodule PhoenixActiveLink do
     Enum.any? controller_actions, fn {controller, action} ->
       (controller == :any or controller == conn.private.phoenix_controller) and
         (action == :any or action == conn.private.phoenix_action)
+    end
+  end
+
+  defp request_path_with_params(conn) do
+    case conn.query_string do
+      "" -> conn.request_path
+      query_string -> conn.request_path <> "?" <> query_string
     end
   end
 

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -41,6 +41,13 @@ defmodule PhoenixActiveLinkTest do
     refute active_path?(conn(path: "/foo"), to: "/foo/", active: :exact)
   end
 
+  test "active_path? when :acitve is :exact_with_params" do
+    assert active_path?(conn(path: "/foo", query_string: "bar=1"), to: "/foo?bar=1", active: :exact_with_params)
+    refute active_path?(conn(path: "/foo", query_string: "bar=1&baz=2"), to: "/foo?bar=1", active: :exact_with_params)
+    assert active_path?(conn(path: "/foo", query_string: "bar[x]=1&bar[y]=1"), to: "/foo?bar[x]=1&bar[y]=1", active: :exact_with_params)
+    refute active_path?(conn(path: "/foo", query_string: "bar=baz%20foo"), to: "/foo?bar=baz foo", active: :exact_with_params)
+  end
+
   test "active_path? when :active is a regex" do
     assert active_path?(conn(path: "/foo"), active: ~r(^/foo.*))
     refute active_path?(conn(path: "/bar/foo"), active: ~r(^/foo.*))

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,6 +5,7 @@ defmodule TestHelpers do
     %Plug.Conn{}
     |> Map.put(:private, make_private(opts))
     |> Map.put(:request_path, opts[:path])
+    |> Map.put(:query_string, opts[:query_string] || "")
   end
 
   defp make_private(opts) do


### PR DESCRIPTION
This will add the `query string` as is to the `request_path` and checks if the `to` and new `request_path` are equal.