### PR TITLE
Add the active option :inclusive_with_params

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -23,6 +23,8 @@ defmodule PhoenixActiveLink do
   """
 
   use Phoenix.HTML
+  import Plug.Conn
+  alias Plug.Conn.Query
 
   @opts ~w(active wrap_tag class_active class_inactive active_disable wrap_tag_opts)a
 
@@ -93,6 +95,10 @@ defmodule PhoenixActiveLink do
     * `:exact_with_params`     - Will return `true` if the current path and the link path are exactly the same,
        including trailing slashes and query string as is.
 
+    * `:inclusive_with_params` - Will return `true` if the current path is equal to the link path and the query params of the current path are included to the link path.
+        For example, `active_path?(conn, to: "/foo?bar=2")` will return `true` if the path is `"/foo?bar=2"` or `"/foo?baz=2&bar=2"`.
+        For example, `active_path?(conn, to: "/foo?bar=2")` will return `false` if the path is `"/foobaz?bar=2"`.
+
   ## Examples
 
   ```elixir
@@ -101,6 +107,7 @@ defmodule PhoenixActiveLink do
   active_path?(conn, to: "/foo", active: :exclusive)
   active_path?(conn, to: "/foo", active: ~r(^/foo/[0-9]+))
   active_path?(conn, to: "/foo", active: [{MyController, :index}, {OtherController, :any}])
+  active_path?(conn, to: "/foo?baz=2", active: :inclusive_with_params)
   ```
 
   """
@@ -113,6 +120,7 @@ defmodule PhoenixActiveLink do
       :exclusive -> String.trim_trailing(conn.request_path, "/") == String.trim_trailing(to, "/")
       :exact     -> conn.request_path == to
       :exact_with_params -> request_path_with_params(conn) == to
+      :inclusive_with_params -> compare_path_and_params(conn, to)
       %Regex{} = regex -> Regex.match?(regex, conn.request_path)
       controller_actions when is_list(controller_actions) ->
         controller_actions_active?(conn, controller_actions)
@@ -139,6 +147,26 @@ defmodule PhoenixActiveLink do
       query_string -> conn.request_path <> "?" <> query_string
     end
   end
+
+  defp compare_path_and_params(conn, to) do
+    %{query_params: request_params} = fetch_query_params(conn)
+
+    with [path, query_params] <- String.split(to, "?"),
+         true <- conn.request_path == path do
+      decoded_params =
+        query_params
+        |> Query.decode()
+
+      map_include?(request_params, decoded_params)
+    else
+      [path] -> conn.request_path == path
+      false -> false
+    end
+  end
+
+  defp map_include?(map, {key, %{} = value}), do: map_include?(map[key], value)
+  defp map_include?(map, {key, value}), do: map[key] == value
+  defp map_include?(in_map, %{} = map), do: Enum.all?(map, &map_include?(in_map, &1))
 
   defp wrap_tag_opts(extra_class, opts) do
     Keyword.get(opts, :wrap_tag_opts, [])

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -48,6 +48,16 @@ defmodule PhoenixActiveLinkTest do
     refute active_path?(conn(path: "/foo", query_string: "bar=baz%20foo"), to: "/foo?bar=baz foo", active: :exact_with_params)
   end
 
+  test "active_path? when :active is :inclusive_with_params" do
+    assert active_path?(conn(path: "/foo", query_string: "bar=2&baz=2"), to: "/foo", active: :inclusive_with_params)
+    assert active_path?(conn(path: "/foo", query_string: "bar=2&baz=2"), to: "/foo?baz=2", active: :inclusive_with_params)
+    assert active_path?(conn(path: "/foo", query_string: "bar%5Bx%5D=2&bar%5By%5D=2"), to: "/foo?bar[x]=2", active: :inclusive_with_params)
+    assert active_path?(conn(path: "/foo", query_string: "bar[x]=2&bar[y]=2"), to: "/foo?bar[x]=2", active: :inclusive_with_params)
+    refute active_path?(conn(path: "/foo", query_string: "bar=2&baz=2"), to: "/foo?baz=2&bax=6", active: :inclusive_with_params)
+    refute active_path?(conn(path: "/foo", query_string: "bar[x]=2&bar[y]=2"), to: "/foo?bar[x]=2&bar[z]=6", active: :inclusive_with_params)
+    refute active_path?(conn(path: "/foo", query_string: "bar=2&baz=2"), to: "/foobar?baz=2",active: :inclusive_with_params)
+  end
+
   test "active_path? when :active is a regex" do
     assert active_path?(conn(path: "/foo"), active: ~r(^/foo.*))
     refute active_path?(conn(path: "/bar/foo"), active: ~r(^/foo.*))


### PR DESCRIPTION
This will check if the query params of the link path are included in the current path.