### PR TITLE
Parse paths to strip any query parameters

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -131,7 +131,11 @@ defmodule PhoenixActiveLink do
   # NOTE: root path is an exception, otherwise it would be active all the time
   defp starts_with_path?(request_path, "/") when request_path != "/", do: false
   defp starts_with_path?(request_path, to) do
-    String.starts_with?(request_path, String.trim_trailing(to, "/"))
+    # Parse both paths to strip any query parameters
+    %{path: request_path} = URI.parse(request_path)
+    %{path: to_path} = URI.parse(to)
+
+    String.starts_with?(request_path, String.trim_trailing(to_path, "/"))
   end
 
   defp controller_actions_active?(conn, controller_actions) do

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -20,6 +20,8 @@ defmodule PhoenixActiveLinkTest do
     refute active_path?(conn(path: "/foo"), to: "/foo/bar", active: :inclusive)
     assert active_path?(conn(path: "/foo/"), to: "/foo", active: :inclusive)
     assert active_path?(conn(path: "/foo"), to: "/foo/", active: :inclusive)
+    assert active_path?(conn(path: "/foo"), to: "/foo?param=bar", active: :inclusive)
+    assert active_path?(conn(path: "/foo?param=bar"), to: "/foo", active: :inclusive)
     refute active_path?(conn(path: "/foo"), to: "/", active: :inclusive)
     refute active_path?(conn(path: "/"), to: "/foo", active: :inclusive)
   end


### PR DESCRIPTION
When using the `:inclusive` option, I expected the comparison to ignore any query parameters. This is also how the `active_link_to` gem handles theses links (https://github.com/comfy/active_link_to/blob/master/test/active_link_to_test.rb#L46). 
This PR strips any query parameters before doing the comparison.