### PR TITLE
Fix inclusive_with_params

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -167,7 +167,7 @@ defmodule PhoenixActiveLink do
     %{query_params: request_params} = fetch_query_params(conn)
 
     with [path, query_params] <- String.split(to, "?"),
-         true <- conn.request_path == path do
+         true <- starts_with_path?(conn.request_path, path) do
       decoded_params =
         query_params
         |> Query.decode()

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -124,4 +124,8 @@ defmodule PhoenixActiveLinkTest do
   after
     Application.put_env(:phoenix_active_link, :defaults, [])
   end
+
+  test "active_link when :active is :inclusive_with_params for subpath" do
+    assert active_path?(conn(path: "/foo/bar", query_string: "foo=2"), to: "/foo?foo=2", active: :inclusive_with_params)
+  end
 end


### PR DESCRIPTION
`:inclusive_with_params` check for exact match of path BUT SHOULD follows
the `:inclusive` options rules.