### PR TITLE
Add aria_current option that adds aria-current attribute to active link

### DIFF
--- a/lib/phoenix_active_link.ex
+++ b/lib/phoenix_active_link.ex
@@ -42,6 +42,7 @@ defmodule PhoenixActiveLink do
     * `:class_active`   - The class to add when the link is active. Defaults to `"active"`
     * `:class_inactive` - The class to add when the link is not active. Empty by default.
     * `:active_disable` - Uses a `span` element instead of an anchor when not active.
+    * `:aria_current`   - The `aria-current` value to add when the link is active. Empty by default.
 
   ## Examples
 
@@ -60,6 +61,7 @@ defmodule PhoenixActiveLink do
     active? = active_path?(conn, opts)
     extra_class = extra_class(active?, opts)
     opts = append_class(opts, extra_class)
+    opts = aria_current(opts, active?)
     link = make_link(active?, text, opts)
     cond do
       tag = opts[:wrap_tag] -> content_tag(tag, link, wrap_tag_opts(extra_class, opts))
@@ -213,6 +215,14 @@ defmodule PhoenixActiveLink do
       |> Enum.reject(&(&1 == ""))
       |> Enum.join(" ")
     Keyword.put(opts, :class, class)
+  end
+
+  defp aria_current(opts, active?) do
+    if active? do
+      opts
+    else
+      Keyword.delete(opts, :aria_current)
+    end
   end
 
   defp link_opts(opts) do

--- a/test/phoenix_active_link_test.exs
+++ b/test/phoenix_active_link_test.exs
@@ -81,7 +81,7 @@ defmodule PhoenixActiveLinkTest do
     assert active_path?(conn, active: [{Foo, :any}])
     refute active_path?(conn, active: [{Bar, Foo}])
   end
-  
+
   test "active_link without :wrap_tag" do
     assert active_link(conn(path: "/"), "Link", to: "/foo") == link("Link", to: "/foo", class: "")
     assert active_link(conn(path: "/foo"), "Link", to: "/foo") == link("Link", to: "/foo", class: "active")
@@ -112,6 +112,14 @@ defmodule PhoenixActiveLinkTest do
     expected = content_tag(:li, link("Link", to: "/foo", class: "disabled"), class: "disabled foo")
     link = active_link(conn(path: "/bar"), "Link", to: "/foo", class_inactive: "disabled", wrap_tag: :li, wrap_tag_opts: [class: "foo"])
     assert link == expected
+  end
+
+  test "active_link with :aria_current" do
+    expected = content_tag(:li, link("Link", to: "/foo", class: "active", aria_current: "page"), class: "active")
+    assert active_link(conn(path: "/foo"), "Link", to: "/foo", wrap_tag: :li, aria_current: "page") == expected
+
+    expected = content_tag(:li, link("Link", to: "/foo", class: ""), class: "")
+    assert active_link(conn(path: "/bar"), "Link", to: "/foo", wrap_tag: :li, aria_current: "page") == expected
   end
 
   test "customize defaults" do


### PR DESCRIPTION
This PR adds the option to add an `aria-current` attribute with value to an active link. Useful in a top menu, breadcrumbs, steps etc.

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current

